### PR TITLE
Fixes everything*

### DIFF
--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -39,6 +39,14 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
 ///Is the loop moving the movable outside its control, like it's an external force? e.g. footsteps won't play if enabled.
 #define MOVEMENT_LOOP_OUTSIDE_CONTROL (1<<4)
 
+// Movement loop status flags
+/// Has the loop been paused, soon to be resumed?
+#define MOVELOOP_STATUS_PAUSED (1<<0)
+/// Is the loop running? (Is true even when paused)
+#define MOVELOOP_STATUS_RUNNING (1<<1)
+/// Is the loop queued in a subsystem?
+#define MOVELOOP_STATUS_QUEUED (1<<2)
+
 /**
  * Returns a bitfield containing flags both present in `flags` arg and the `processing_move_loop_flags` move_packet variable.
  * Has no use outside of procs called within the movement proc chain.

--- a/code/controllers/subsystem/movement/move_handler.dm
+++ b/code/controllers/subsystem/movement/move_handler.dm
@@ -121,9 +121,12 @@ SUBSYSTEM_DEF(move_manager)
 
 	var/datum/controller/subsystem/movement/current_subsystem = running_loop.controller
 
-	current_subsystem.remove_loop(running_loop)
-	contesting_subsystem.add_loop(contestant)
+	var/current_running_loop = running_loop
 	running_loop = contestant
+	current_subsystem.remove_loop(current_running_loop)
+	if(running_loop != contestant) // A signal registrant could have messed with things
+		return FALSE
+	contesting_subsystem.add_loop(contestant)
 	return TRUE
 
 ///Tries to figure out the current favorite loop to run. More complex then just deciding between two different loops, assumes no running loop currently exists
@@ -138,7 +141,7 @@ SUBSYSTEM_DEF(move_manager)
 		var/datum/move_loop/checking = existing_loops[owner]
 		if(checking.flags & MOVEMENT_LOOP_IGNORE_PRIORITY)
 			continue
-		if(favorite && favorite.priority < checking.priority)
+		if(favorite && favorite.priority > checking.priority)
 			continue
 		favorite = checking
 
@@ -152,8 +155,8 @@ SUBSYSTEM_DEF(move_manager)
 
 /datum/movement_packet/proc/remove_loop(datum/controller/subsystem/movement/remove_from, datum/move_loop/loop_to_remove)
 	if(loop_to_remove == running_loop)
-		remove_from.remove_loop(loop_to_remove)
 		running_loop = null
+		remove_from.remove_loop(loop_to_remove)
 	if(loop_to_remove.flags & MOVEMENT_LOOP_IGNORE_PRIORITY)
 		remove_from.remove_loop(loop_to_remove)
 	if(QDELETED(src))

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -25,10 +25,8 @@
 	///The time we are CURRENTLY queued for processing
 	///Do not modify this directly
 	var/queued_time = -1
-	///Is this loop running or not
-	var/running = FALSE
-	///Track if we're currently paused
-	var/paused = FALSE
+	/// Status bitfield for what state the move loop is currently in
+	var/status = NONE
 
 /datum/move_loop/New(datum/movement_packet/owner, datum/controller/subsystem/movement/controller, atom/moving, priority, flags, datum/extra_info)
 	src.owner = owner
@@ -59,7 +57,7 @@
 /datum/move_loop/proc/loop_started()
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_START)
-	running = TRUE
+	status |= MOVELOOP_STATUS_RUNNING
 	//If this is our first time starting to move with this loop
 	//And we're meant to start instantly
 	if(!timer && flags & MOVEMENT_LOOP_START_FAST)
@@ -70,7 +68,7 @@
 ///Called when a loop is stopped, doesn't stop the loop itself
 /datum/move_loop/proc/loop_stopped()
 	SHOULD_CALL_PARENT(TRUE)
-	running = FALSE
+	status &= ~MOVELOOP_STATUS_RUNNING
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_STOP)
 
 /datum/move_loop/proc/info_deleted(datum/source)
@@ -93,7 +91,7 @@
 ///Pauses the move loop for some passed in period
 ///This functionally means shifting its timer up, and clearing it from its current bucket
 /datum/move_loop/proc/pause_for(time)
-	if(!controller || !running) //No controller or not running? go away
+	if(!controller || !(status & MOVELOOP_STATUS_RUNNING)) //No controller or not running? go away
 		return
 	//Dequeue us from our current bucket
 	controller.dequeue_loop(src)
@@ -143,21 +141,21 @@
 
 ///Pause our loop untill restarted with resume_loop()
 /datum/move_loop/proc/pause_loop()
-	if(!controller || !running || paused) //we dead
+	if(!controller || !(status & MOVELOOP_STATUS_RUNNING) || (status & MOVELOOP_STATUS_PAUSED)) //we dead
 		return
 
 	//Dequeue us from our current bucket
 	controller.dequeue_loop(src)
-	paused = TRUE
+	status |= MOVELOOP_STATUS_PAUSED
 
 ///Resume our loop after being paused by pause_loop()
 /datum/move_loop/proc/resume_loop()
-	if(!controller || !running || !paused)
+	if(!controller || (status & MOVELOOP_STATUS_RUNNING|MOVELOOP_STATUS_PAUSED) != (MOVELOOP_STATUS_RUNNING|MOVELOOP_STATUS_PAUSED))
 		return
 
-	controller.queue_loop(src)
 	timer = world.time
-	paused = FALSE
+	controller.queue_loop(src)
+	status &= ~MOVELOOP_STATUS_PAUSED
 
 ///Removes the atom from some movement subsystem. Defaults to SSmovement
 /datum/controller/subsystem/move_manager/proc/stop_looping(atom/movable/moving, datum/controller/subsystem/movement/subsystem = SSmovement)

--- a/code/datums/components/drift.dm
+++ b/code/datums/components/drift.dm
@@ -34,7 +34,7 @@
 	RegisterSignal(drifting_loop, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(after_move))
 	RegisterSignal(drifting_loop, COMSIG_QDELETING, PROC_REF(loop_death))
 	RegisterSignal(movable_parent, COMSIG_MOVABLE_NEWTONIAN_MOVE, PROC_REF(newtonian_impulse))
-	if(drifting_loop.running)
+	if(drifting_loop.status & MOVELOOP_STATUS_RUNNING)
 		drifting_start(drifting_loop) // There's a good chance it'll autostart, gotta catch that
 
 	var/visual_delay = movable_parent.inertia_move_delay

--- a/code/datums/components/shuttle_cling.dm
+++ b/code/datums/components/shuttle_cling.dm
@@ -90,9 +90,9 @@
 		return
 
 	//Do pause/unpause/nothing for the hyperloop
-	if(should_loop && hyperloop.paused)
+	if(should_loop && hyperloop.status & MOVELOOP_STATUS_PAUSED)
 		hyperloop.resume_loop()
-	else if(!should_loop && !hyperloop.paused)
+	else if(!should_loop && !(hyperloop.status & MOVELOOP_STATUS_PAUSED))
 		hyperloop.pause_loop()
 
 ///Check if we're "holding on" to the shuttle


### PR DESCRIPTION
*Anything not fixed is not covered by this statement

While I was writing this I considered more whether we should even be allowing things to requeue while a loop is processing. From an external view, for all things know, a loop is queued. That you're allowed to queue a loop again only during the subsystem process is a bit strange when for all external code is aware the loop should still be queued. It also simplifies the code a little bit to not allow that sort of thing. Code that wants to requeue should be unqueueing first as is normal anywhere else.